### PR TITLE
Change the out() return to include correct version JSON.

### DIFF
--- a/pypi_resource/out.py
+++ b/pypi_resource/out.py
@@ -58,11 +58,12 @@ def out(srcdir, input):
     common.msg('Finding package to upload')
     pkgpath = find_package(input['params']['glob'], srcdir)
     response = common.get_package_info(pkgpath)
+    version = str(response['version'])
 
-    common.msg('Uploading {} version {}', pkgpath, response['version'])
+    common.msg('Uploading {} version {}', pkgpath, version)
     upload_package(pkgpath, input)
 
-    return {'version': response['version']}
+    return {'version': {'version': version}}
 
 
 def main():


### PR DESCRIPTION
Discovered when integrating with Concourse v4.2.1, formatting taken from original cf-platform-eng/concourse-pypi-resource.

You are welcome to this change, if you think its OK. I tested it today with Concourse 4.2.1 (latest AFAIK) and it worked well.

Thanks.